### PR TITLE
Update api version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ nbdist/
 nbactions.xml
 nb-configuration.xml
 .nb-gradle/
+.idea/

--- a/METno.php
+++ b/METno.php
@@ -373,9 +373,11 @@ class METno extends METnoFactory {
                                             "difference"    => $difference,     // difference in hours betwen from to to
                                             "symbol"        => new self::$classSymbol(self::getAttributeValue($symbolAttributes, "number",0),
                                                                                      self::getAttributeValue($symbolAttributes, "id")),
-                                            "precipitation" => new self::$classPrecipitation(self::getAttributeValue($precipitationAttributes, "value",1),
-                                                                                     self::getAttributeValue($precipitationAttributes, "minvalue",1),
-                                                                                     self::getAttributeValue($precipitationAttributes, "maxvalue",1))
+                                            "precipitation" => new self::$classPrecipitation(
+                                                self::getAttributeValue($precipitationAttributes, "value", 1),
+                                                self::getAttributeValue($precipitationAttributes, "minvalue", 1),
+                                                self::getAttributeValue($precipitationAttributes, "maxvalue", 1)
+                                            )
                                         );
 
                                     }
@@ -509,5 +511,3 @@ class METno extends METnoFactory {
         return $this->error(new Exception("Forecast for date $date doesn't exist", METno::DATA_EMPTY));
     }
 }
-
-?>

--- a/METnoDay.php
+++ b/METnoDay.php
@@ -207,21 +207,28 @@ class METnoDay extends METnoForecast {
     public function isToday() {
         return $this->today;
     }
-    
+
     /**
      * Returns self becouse of overiding the hour forecast
      * @return \METnoDay
      */
-    public function getMETDay() {
+    public function getMETDay()
+    {
         return $this;
     }
-    
+
+    public function getHourWeather()
+    {
+        return $this->hourWeather;
+    }
+
     /**
      * Return the hour forecast if exist, if not, return self
      * @param int $hour
      * @return METnoForecast
      */
-    public function getForecastForHour($hour) {
+    public function getForecastForHour($hour)
+    {
         if (isset($this->hourWeather[$hour])) {
             return $this->hourWeather[$hour];
         } else {
@@ -294,4 +301,3 @@ class METnoDay extends METnoForecast {
     }
     
 }
-?>

--- a/METnoForecast.php
+++ b/METnoForecast.php
@@ -11,107 +11,109 @@
 class METnoForecast {
     private $parent                     = false;
     
-    /**
-     *
-     * @var METnoSymbol 
-     */
+    /** @var METnoSymbol */
     protected $symbol                   = 0;
-   
-    
+
     protected $date                     = "";
     protected $hour                     = "";
-            
+
     /**
-     * Temperature in celcius
-     * @var type 
-     */
-    protected $temperature              = 0;
-    
+	 * Temperature in celcius
+	 * @var float
+	 */
+	protected $temperature 				= 0.0;
+
     /**
      * Wind speed in m/s
-     * @var decimal 
+     * @var float
      */
-    protected $windSpeed                = 0;
-    
-    protected $windDegrees              = 0;
-    
+    protected $windSpeed                = 0.0;
+
+    /** @var int */
+    protected $windSpeedBeufort         = 0;
+
+	/** @var float */
+    protected $windDegrees              = 0.0;
+
     protected $windOrientation          = "NONE";
-    
+
     /**
      * Precipitation (srážky) in mm
-     * @var type 
+     * @var null|METnoPrecipitation
      */
-    protected $precipitation            = 0;
-    
+    protected $precipitation;
+
     protected $precipitationInHours     = array();
 
 
     /**
      * Humidity (vlhkost) in percente
-     * @var int 
+     * @var float
      */
-    protected $humidity                 = 0;
-           
+    protected $humidity                 = 0.0;
+
     /**
      * Pressure in hPa (default)
-     * 
-     * @var type 
+     *
+     * @var float
      */
-    protected $pressure                 = 0;
+    protected $pressure                 = 0.0;
     protected $pressureUnit             = "hPa";
 
 
     /**
      * Fog in percente
-     * @var int 
+     * @var int
      */
     protected $fog                      = 0;
-    
-    protected $cloudiness               = 0;
-    
+
+    /** @var float */
+    protected $cloudiness               = 0.0;
+
     protected $lowClouds                = 0;
-    
+
     protected $mediumClouds             = 0;
-    
-    protected $highClouds               = 0;    
-    
-    
+
+    protected $highClouds               = 0;
+
+
     public function __construct(METnoDay $parent,$date,$hour,SimpleXMLElement $mainXMLElement,$symbolsArray) {
         $this->parent   = $parent;
-        
+
         $this->date     = $date;
-        $this->hour     = $hour;        
-        
+        $this->hour     = $hour;
+
         /**
          * Get all the datas from main XML element - weather info (detail)
          */
         
         if (isset($mainXMLElement->temperature)) {
-            $this->temperature      = METnoFactory::getAttributeValue($mainXMLElement->temperature->attributes(), "value",  METnoFactory::getTemperatureDecimals());
+			$this->temperature = (float) METnoFactory::getAttributeValue($mainXMLElement->temperature->attributes(), "value", METnoFactory::getTemperatureDecimals());
         }
         
         if (isset($mainXMLElement->windSpeed)) {
-            $this->windSpeed        = METnoFactory::getAttributeValue($mainXMLElement->windSpeed->attributes(), "value",  METnoFactory::getWindSpeedDecimals());
+            $this->windSpeed        = (float) METnoFactory::getAttributeValue($mainXMLElement->windSpeed->attributes(), "mps",  METnoFactory::getWindSpeedDecimals());
+            $this->windSpeedBeufort = (int) METnoFactory::getAttributeValue($mainXMLElement->windSpeed->attributes(), "beaufort");
         }
         
         if (isset($mainXMLElement->windDirection)) {
             $attribtues             = $mainXMLElement->windDirection->attributes();
-            $this->windDegrees      = METnoFactory::getAttributeValue($attribtues, "deg",0);
+            $this->windDegrees      = (float) METnoFactory::getAttributeValue($attribtues, "deg",0);
             $this->windOrientation  = METnoFactory::getAttributeValue($attribtues, "name");
         }
         
         if (isset($mainXMLElement->humidity)) {
-            $this->humidity         = METnoFactory::getAttributeValue($mainXMLElement->humidity->attributes(), "value",  METnoFactory::getPercenteDecimals());
+            $this->humidity         = (float) METnoFactory::getAttributeValue($mainXMLElement->humidity->attributes(), "value",  METnoFactory::getPercenteDecimals());
         }
         
         if (isset($mainXMLElement->pressure)) {
             $attribtues             = $mainXMLElement->pressure->attributes();
-            $this->pressure         = METnoFactory::getAttributeValue($attribtues, "value",1);
+            $this->pressure         = (float) METnoFactory::getAttributeValue($attribtues, "value",1);
             $this->pressureUnit     = METnoFactory::getAttributeValue($attribtues, "unit");
         }
         
         if (isset($mainXMLElement->cloudiness)) {
-            $this->cloudiness       = METnoFactory::getAttributeValue($mainXMLElement->cloudiness->attributes(), "percent",  METnoFactory::getPercenteDecimals());
+            $this->cloudiness       = (float) METnoFactory::getAttributeValue($mainXMLElement->cloudiness->attributes(), "percent",  METnoFactory::getPercenteDecimals());
         }
         
         if (isset($mainXMLElement->fog)) {
@@ -193,15 +195,23 @@ class METnoForecast {
     }
 
     /**
-     * @return decimal
+     * @return float
      */
     public function getWindSpeed()
     {
         return $this->windSpeed;
     }
 
+	/**
+	 * @return int
+	 */
+	public function getWindSpeedBeufort()
+	{
+		return $this->windSpeedBeufort;
+	}
+
     /**
-     * @return bool|int|string
+     * @return float
      */
     public function getWindDegrees()
     {
@@ -216,9 +226,9 @@ class METnoForecast {
         return $this->windOrientation;
     }
 
-    /**
-     * @return type
-     */
+	/**
+	 * @return METnoPrecipitation|null
+	 */
     public function getPrecipitation()
     {
         return $this->precipitation;
@@ -233,7 +243,7 @@ class METnoForecast {
     }
 
     /**
-     * @return int
+     * @return float
      */
     public function getHumidity()
     {
@@ -241,7 +251,7 @@ class METnoForecast {
     }
 
     /**
-     * @return type
+     * @return float
      */
     public function getPressure()
     {
@@ -265,7 +275,7 @@ class METnoForecast {
     }
 
     /**
-     * @return bool|int|string
+     * @return float
      */
     public function getCloudiness()
     {

--- a/METnoForecast.php
+++ b/METnoForecast.php
@@ -182,15 +182,117 @@ class METnoForecast {
     public function getTemperature() {
         return $this->temperature;
     }
-    
+
     /**
      * Returns the symbol for the weather
      * @return METnoSymbol
      */
-    public function getSymbol() {
+    public function getSymbol()
+    {
         return $this->symbol;
     }
-    
-    
+
+    /**
+     * @return decimal
+     */
+    public function getWindSpeed()
+    {
+        return $this->windSpeed;
+    }
+
+    /**
+     * @return bool|int|string
+     */
+    public function getWindDegrees()
+    {
+        return $this->windDegrees;
+    }
+
+    /**
+     * @return bool|int|string
+     */
+    public function getWindOrientation()
+    {
+        return $this->windOrientation;
+    }
+
+    /**
+     * @return type
+     */
+    public function getPrecipitation()
+    {
+        return $this->precipitation;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPrecipitationInHours()
+    {
+        return $this->precipitationInHours;
+    }
+
+    /**
+     * @return int
+     */
+    public function getHumidity()
+    {
+        return $this->humidity;
+    }
+
+    /**
+     * @return type
+     */
+    public function getPressure()
+    {
+        return $this->pressure;
+    }
+
+    /**
+     * @return bool|int|string
+     */
+    public function getPressureUnit()
+    {
+        return $this->pressureUnit;
+    }
+
+    /**
+     * @return int
+     */
+    public function getFog()
+    {
+        return $this->fog;
+    }
+
+    /**
+     * @return bool|int|string
+     */
+    public function getCloudiness()
+    {
+        return $this->cloudiness;
+    }
+
+    /**
+     * @return bool|int|string
+     */
+    public function getLowClouds()
+    {
+        return $this->lowClouds;
+    }
+
+    /**
+     * @return bool|int|string
+     */
+    public function getMediumClouds()
+    {
+        return $this->mediumClouds;
+    }
+
+    /**
+     * @return bool|int|string
+     */
+    public function getHighClouds()
+    {
+        return $this->highClouds;
+    }
 }
-?>

--- a/METnoPrecipitation.php
+++ b/METnoPrecipitation.php
@@ -8,31 +8,41 @@
  * 
  */
 
-class METnoPrecipitation {
-    protected $value    = 0;
-    protected $min      = 0;
-    protected $max      = 0;
-    
-    public function __construct($value,$min,$max) {
-        $this->value    = $value;
-        $this->min      = $min;
-        $this->max      = $max;
+class METnoPrecipitation
+{
+    /** @var float */
+    protected $value = 0.0;
+
+    /** @var float */
+    protected $min = 0.0;
+
+    /** @var float */
+    protected $max = 0.0;
+
+    public function __construct($value, $min, $max)
+    {
+        $this->value = $value;
+        $this->min = $min;
+        $this->max = $max;
     }
-    
-    public function __toString() {
+
+    public function __toString()
+    {
         return "$this->value";
     }
-    
-    public function getValue() {
+
+    public function getValue()
+    {
         return $this->value;
     }
-    
-    public function getMIN() {
+
+    public function getMIN()
+    {
         return $this->min;
     }
-    
-    public function getMAX() {
+
+    public function getMAX()
+    {
         return $this->max;
     }
 }
-?>

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php" : ">=5.3.0",
         "ext-curl" : "*"
+        "ext-dom" : "*"
     },
     "autoload" : {
         "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "require": {
         "php" : ">=5.3.0",
         "ext-curl" : "*",
-        "ext-dom" : "*"
+        "ext-dom" : "*",
+        "ext-simplexml" : "*"
     },
     "autoload" : {
         "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "minimum-stability": "dev",
     "require": {
         "php" : ">=5.3.0",
-        "ext-curl" : "*"
+        "ext-curl" : "*",
         "ext-dom" : "*"
     },
     "autoload" : {


### PR DESCRIPTION
Update endpointu na METno, verze 1.9 je už deprecated, změněno na 2.0. Bylo nutné do endpointu přidat classic, ať vrací XML, se kterým teď balíček počítá, data by měla být stejná.

Dále upravena kontrola response z METno. Balíček natvrdo kontroloval stavový kód 200. U endpointu na verzi METno 1.9 se vracelo 203, u verze 2.0 se vrací 304, pokud není obsah změněn. Upraveno tedy tak, že kontroluje jen validní XML.

Jinak composer.json a readme.md asi nebylo z dřívějška mergnuto do masteru, protože jsou nyní uvedeny jako změněné, ale ty změny jsou tam už z roku 2018, dle historie gitu. Já jen přidával ext-dom